### PR TITLE
fix: ensure proper application reload on configuration change and reg…

### DIFF
--- a/config/configs.go
+++ b/config/configs.go
@@ -14,9 +14,9 @@ var MapLevel = map[string]slog.Level{
 	"ERROR": slog.LevelError,
 }
 
-var Confs config
+var Confs Config
 
-type config struct {
+type Config struct {
 	Server server `yaml:"server"`
 	Logger logger `yaml:"logger"`
 }


### PR DESCRIPTION


1. **Application Reload on Configuration Change:** 
   The application now properly reloads when a configuration change is detected. This fix improves the signal handling logic, ensuring that the application correctly reinitializes its environment when it receives a SIGHUP signal.

2. **Prometheus Metrics Registration:**
   Introduced the `sync.Once` pattern to handle the registration of Prometheus metrics within the middleware. This ensures that the metrics are registered only once during the application's lifecycle, preventing any potential duplication or conflicts.